### PR TITLE
Feat/modify periodic table v2 actual changes

### DIFF
--- a/src/docs/routes/experimental/periodic-table.tsx
+++ b/src/docs/routes/experimental/periodic-table.tsx
@@ -122,6 +122,45 @@ function OutputTypesDemo() {
 
 const outputTypesSource = __SOURCE__
 
+/* DEMO_START */
+function EnabledSymbolsDemo() {
+  const [selectedElement, setSelectedElement] = useState<any>(null)
+
+  const enabledSymbols = [
+    "Mn", "Fe", "Co", "Ni", "Cu", "Zn", "Ga", "Ge", "As", "Se",
+    "Br", "Kr", "Rb", "Sr", "Y", "Zr", "Nb", "Mo", "Tc", "Ru",
+    "Rh", "Pd", "Ag", "Cd", "In", "Sn", "Sb", "Pr", "Nd", "Pm",
+    "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu",
+    "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt", "Au", "Hg", "Tl",
+    "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac", "Th", "Pa",
+    "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf",
+  ]
+
+  return (
+    <div className="space-y-4">
+      <PeriodicTable
+        variant="grid"
+        outputType="element"
+        outputFormat="object"
+        onElementSelect={setSelectedElement}
+        placeholder="Choose an element..."
+        enabledSymbols={enabledSymbols}
+      />
+
+      {selectedElement && (
+        <div className="space-y-2">
+          <h4 className="font-medium">Selected Element:</h4>
+          <Badge variant="secondary">{selectedElement.symbol}</Badge>
+          <span className="font-medium ml-2">{selectedElement.name}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+/* DEMO_END */
+
+const enabledSymbolsSource = __SOURCE__
+
 function PeriodicTablePage() {
 
 
@@ -156,6 +195,19 @@ function PeriodicTablePage() {
               <DemoContainer
                 demo={<DefaultPeriodicTableDemo />}
                 source={defaultPeriodicTableSource}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Grid Variant with Enabled Symbols</CardTitle>
+              <CardDescription>Restrict selectable elements to a subset using enabledSymbols</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DemoContainer
+                demo={<EnabledSymbolsDemo />}
+                source={enabledSymbolsSource}
               />
             </CardContent>
           </Card>

--- a/src/ui/experimental/periodic-table.tsx
+++ b/src/ui/experimental/periodic-table.tsx
@@ -42,14 +42,17 @@ export interface PeriodicTableProps {
   placeholder?: string
   className?: string
   disabled?: boolean
+  availableElements?: string[]
 }
 
 function ElementCard({
   element,
   onClick,
+  disabled,
 }: {
   element: Element
   onClick?: () => void
+  disabled?: boolean
 }) {
   const categoryInfo = ELEMENT_CATEGORIES[element.category]
 
@@ -61,12 +64,15 @@ function ElementCard({
       <HoverCardTrigger>
         <div
           className={cn(
-            'relative w-12 h-12 border border-border rounded cursor-pointer transition-all hover:scale-105 hover:shadow-md',
+            'relative w-12 h-12 border border-border rounded transition-all',
             categoryInfo.lightColor,
             'font-medium text-center flex flex-col justify-center items-center',
-            onClick && 'hover:ring-1 hover:ring-ring hover:ring-offset-1'
+            disabled
+              ? 'opacity-40 cursor-not-allowed'
+              : 'cursor-pointer hover:scale-105 hover:shadow-md',
+            !disabled && onClick && 'hover:ring-1 hover:ring-ring hover:ring-offset-1'
           )}
-          onClick={onClick}
+          onClick={disabled ? undefined : onClick}
         >
           <div className="font-bold absolute top-0.5 left-0.5 text-[8px] opacity-80 leading-none">
             {element.atomicNumber}
@@ -184,11 +190,17 @@ function PeriodicTableGrid({
   elements,
   onElementSelect,
   selectedCategories,
+  availableElements,
 }: {
   elements: Element[]
   onElementSelect: (element: Element) => void
   selectedCategories: Set<ElementCategory>
+  availableElements?: string[]
 }) {
+  const availableSet = React.useMemo(
+    () => new Set(availableElements ?? []),
+    [availableElements]
+  )
   const filteredElements = elements.filter(
     (element) =>
       selectedCategories.size === 0 || selectedCategories.has(element.category)
@@ -341,11 +353,14 @@ function PeriodicTableGrid({
       return <div key={atomicNumber} className="w-12 h-12" />
     }
 
+    const isDisabled = availableSet.size > 0 && !availableSet.has(element.symbol)
+
     return (
       <ElementCard
         key={element.atomicNumber}
         element={element}
         onClick={() => onElementSelect(element)}
+        disabled={isDisabled}
       />
     )
   }
@@ -398,6 +413,7 @@ export function PeriodicTable({
   placeholder = 'Select element...',
   className,
   disabled = false,
+  availableElements,
 }: PeriodicTableProps) {
   const [open, setOpen] = React.useState(false)
   const [selectedElement, setSelectedElement] = React.useState<Element | null>(
@@ -406,6 +422,11 @@ export function PeriodicTable({
   const [selectedCategories, setSelectedCategories] = React.useState<
     Set<ElementCategory>
   >(new Set())
+
+  const availableSet = React.useMemo(
+    () => new Set(availableElements ?? []),
+    [availableElements]
+  )
 
   const handleElementSelect = (element: Element) => {
     setSelectedElement(element)
@@ -503,6 +524,7 @@ export function PeriodicTable({
                           key={element.atomicNumber}
                           value={`${element.name} ${element.symbol} ${element.atomicNumber}`}
                           onSelect={() => handleElementSelect(element)}
+                          disabled={availableSet.size > 0 && !availableSet.has(element.symbol)}
                         >
                           <div className="flex items-center space-x-3 w-full">
                             <div
@@ -589,6 +611,7 @@ export function PeriodicTable({
               elements={PERIODIC_TABLE_DATA}
               onElementSelect={handleElementSelect}
               selectedCategories={selectedCategories}
+              availableElements={availableElements}
             />
           </div>
         </PopoverContent>

--- a/src/ui/experimental/periodic-table.tsx
+++ b/src/ui/experimental/periodic-table.tsx
@@ -191,20 +191,29 @@ function PeriodicTableGrid({
   onElementSelect,
   selectedCategories,
   availableElements,
+  searchQuery = '',
 }: {
   elements: Element[]
   onElementSelect: (element: Element) => void
   selectedCategories: Set<ElementCategory>
   availableElements?: string[]
+  searchQuery?: string
 }) {
   const availableSet = React.useMemo(
     () => new Set(availableElements ?? []),
     [availableElements]
   )
-  const filteredElements = elements.filter(
-    (element) =>
+  const filteredElements = elements.filter((element) => {
+    const matchesCategory =
       selectedCategories.size === 0 || selectedCategories.has(element.category)
-  )
+    const query = searchQuery.toLowerCase().trim()
+    const matchesSearch =
+      query === '' ||
+      element.name.toLowerCase().includes(query) ||
+      element.symbol.toLowerCase().includes(query) ||
+      String(element.atomicNumber).includes(query)
+    return matchesCategory && matchesSearch
+  })
 
   // Create the classic periodic table layout
   // Each array represents the atomic numbers for that period, with null for empty spaces
@@ -422,6 +431,7 @@ export function PeriodicTable({
   const [selectedCategories, setSelectedCategories] = React.useState<
     Set<ElementCategory>
   >(new Set())
+  const [searchQuery, setSearchQuery] = React.useState('')
 
   const availableSet = React.useMemo(
     () => new Set(availableElements ?? []),
@@ -565,7 +575,10 @@ export function PeriodicTable({
   }
   if (variant === 'grid') {
     return (
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={(isOpen) => {
+        setOpen(isOpen)
+        if (!isOpen) setSearchQuery('')
+      }}>
         <PopoverTrigger asChild>
           <Button
             variant="outline"
@@ -597,9 +610,14 @@ export function PeriodicTable({
           align="start"
         >
           <div className="space-y-3">
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-2 border-b pb-2">
               <Search className="h-4 w-4 text-muted-foreground" />
-              <h4 className="font-medium">Select an Element</h4>
+              <input
+                className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                placeholder="Search elements..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
             </div>
 
             <CategoryLegend
@@ -612,6 +630,7 @@ export function PeriodicTable({
               onElementSelect={handleElementSelect}
               selectedCategories={selectedCategories}
               availableElements={availableElements}
+              searchQuery={searchQuery}
             />
           </div>
         </PopoverContent>

--- a/src/ui/experimental/periodic-table.tsx
+++ b/src/ui/experimental/periodic-table.tsx
@@ -42,7 +42,7 @@ export interface PeriodicTableProps {
   placeholder?: string
   className?: string
   disabled?: boolean
-  availableElements?: string[]
+  enabledSymbols?: string[]
 }
 
 function ElementCard({
@@ -190,18 +190,18 @@ function PeriodicTableGrid({
   elements,
   onElementSelect,
   selectedCategories,
-  availableElements,
+  enabledSymbols,
   searchQuery = '',
 }: {
   elements: Element[]
   onElementSelect: (element: Element) => void
   selectedCategories: Set<ElementCategory>
-  availableElements?: string[]
+  enabledSymbols?: string[]
   searchQuery?: string
 }) {
   const availableSet = React.useMemo(
-    () => new Set(availableElements ?? []),
-    [availableElements]
+    () => new Set(enabledSymbols ?? []),
+    [enabledSymbols]
   )
   const filteredElements = elements.filter((element) => {
     const matchesCategory =
@@ -422,7 +422,7 @@ export function PeriodicTable({
   placeholder = 'Select element...',
   className,
   disabled = false,
-  availableElements,
+  enabledSymbols,
 }: PeriodicTableProps) {
   const [open, setOpen] = React.useState(false)
   const [selectedElement, setSelectedElement] = React.useState<Element | null>(
@@ -434,8 +434,8 @@ export function PeriodicTable({
   const [searchQuery, setSearchQuery] = React.useState('')
 
   const availableSet = React.useMemo(
-    () => new Set(availableElements ?? []),
-    [availableElements]
+    () => new Set(enabledSymbols ?? []),
+    [enabledSymbols]
   )
 
   const handleElementSelect = (element: Element) => {
@@ -629,7 +629,7 @@ export function PeriodicTable({
               elements={PERIODIC_TABLE_DATA}
               onElementSelect={handleElementSelect}
               selectedCategories={selectedCategories}
-              availableElements={availableElements}
+              enabledSymbols={enabledSymbols}
               searchQuery={searchQuery}
             />
           </div>


### PR DESCRIPTION
Adding two options

- Add enabledSymbols prop to PeriodicTable component, allowing consumers to specify which chemical symbols are selectable 
  - non-enabled elements appear greyed out and are not clickable in both compact and grid variants
<img width="965" height="508" alt="Screenshot from 2026-03-27 14-57-46" src="https://github.com/user-attachments/assets/5e569153-d0a6-49fb-bdbe-2fa1693deacd" />
- Add search input to the grid variant popover, supporting filtering by element name, symbol, or atomic number
<img width="954" height="618" alt="Screenshot from 2026-03-27 14-58-10" src="https://github.com/user-attachments/assets/8fe6d568-b178-422c-a1eb-fb32aea932af" />