### PR TITLE
H264 Fetch API Component Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@australiansynchrotron/sci-comp-ui",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@australiansynchrotron/sci-comp-ui",
-            "version": "0.0.11",
+            "version": "0.0.12",
             "license": "MIT",
             "dependencies": {
                 "@radix-ui/react-accordion": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@australiansynchrotron/sci-comp-ui",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "private": false,
     "license": "MIT",
     "author": "Australian Synchrotron",

--- a/src/docs/routes/experimental/camera-control-h264.tsx
+++ b/src/docs/routes/experimental/camera-control-h264.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute('/experimental/camera-control-h264')({
 function CameraControlWebsocketH264Demo() {
     const [mousePos, setMousePos] = useState<CameraMousePosition | null>(null);
     const [clickPos, setClickPos] = useState<CameraMousePosition | null>(null);
-    const api = useMemo(() => h264FetchApi('localhost:9999'), []);
+    const api = useMemo(() => h264FetchApi('http://localhost:9999'), []);
     return (
         <div className="w-full h-full">
             <WebsocketH264Provider api={api}>

--- a/src/ui/experimental/camera-control/h264-api.tsx
+++ b/src/ui/experimental/camera-control/h264-api.tsx
@@ -36,8 +36,4 @@ export interface H264Api {
 
     /** Optional: customize WebSocket construction (auth headers, subprotocols, polyfills). */
     wsFactory: (sessionId: string) => WebSocket;
-
-    /** Optional: build absolute HTTP/WS URLs if you don’t want the component to concatenate strings. */
-    buildHttpUrl?: (path: string) => string; // e.g., p => `${base}${p}`
-    buildWsUrl?: (path: string) => string; // e.g., p => `${wssBase}${p}`
 }

--- a/src/ui/experimental/camera-control/h264-api.tsx
+++ b/src/ui/experimental/camera-control/h264-api.tsx
@@ -12,6 +12,31 @@ export const DEFAULT_RESOLUTION: Resolution = {
     height: 1024,
 };
 
+export const COLOUR_MAPPING_OPTIONS: string[] = [
+    'magma',
+    'inferno',
+    'plasma',
+    'viridis',
+    'turbo',
+    'range1',
+    'range2',
+    'shadows',
+    'highlights',
+    'solar',
+    'nominal',
+    'preferred',
+    'total',
+    'spectral',
+    'cool',
+    'heat',
+    'fiery',
+    'blues',
+    'green',
+    'helix',
+];
+
+export type ColourMappingOptionsKey = (typeof COLOUR_MAPPING_OPTIONS)[number];
+
 export interface H264Api {
     /** Create a session if needed. Return the session ID. */
     createSession: (signal?: AbortSignal) => Promise<string>;
@@ -33,6 +58,15 @@ export interface H264Api {
 
     /** Clear crop. */
     clearCrop: (sessionId: string, signal?: AbortSignal) => Promise<void>;
+
+    /** Get current colour mapping. */
+    getColourMapping: (sessionId: string, signal?: AbortSignal) => Promise<ColourMappingOptionsKey>;
+
+    /** Set colour mapping. */
+    setColourMapping: (sessionId: string, colour: ColourMappingOptionsKey, signal?: AbortSignal) => Promise<void>;
+
+    /** Clear colour mapping. */
+    clearColourMapping: (sessionId: string, signal?: AbortSignal) => Promise<void>;
 
     /** Optional: customize WebSocket construction (auth headers, subprotocols, polyfills). */
     wsFactory: (sessionId: string) => WebSocket;

--- a/src/ui/experimental/camera-control/h264-api.tsx
+++ b/src/ui/experimental/camera-control/h264-api.tsx
@@ -7,9 +7,17 @@ export type SessionResolution = Resolution & {
     paddingHeight: number;
 };
 
+export type DataIntensity = { min: number; max: number };
+
+export type DataScaling = { value: number };
+
 export const DEFAULT_RESOLUTION: Resolution = {
     width: 1024,
     height: 1024,
+};
+
+export const DEFAULT_SCALING: DataScaling = {
+    value: 1,
 };
 
 export const COLOUR_MAPPING_OPTIONS: string[] = [
@@ -69,6 +77,24 @@ export interface H264Api {
 
     /** Clear colour mapping. */
     clearColourMapping: (sessionId: string, signal?: AbortSignal) => Promise<void>;
+
+    /** Get current data intensity range - currently, this is shared between all sessions, not per session */
+    getDataIntensity: (signal?: AbortSignal) => Promise<DataIntensity>;
+
+    /** Set data intensity range - currently, this is shared between all sessions, not per session */
+    setDataIntensity: (min: number, max: number, signal?: AbortSignal) => Promise<void>;
+
+    /** Clear data intensity range - currently, this is shared between all sessions, not per session */
+    clearDataIntensity: (signal?: AbortSignal) => Promise<void>;
+
+    /** Get current data scaling power - currently, this is shared between all sessions, not per session */
+    getDataScaling: (signal?: AbortSignal) => Promise<DataScaling>;
+
+    /** Set data scaling power - currently, this is shared between all sessions, not per session */
+    setDataScaling: (value: number, signal?: AbortSignal) => Promise<void>;
+
+    /** Clear data scaling power - currently, this is shared between all sessions, not per session */
+    clearDataScaling: (signal?: AbortSignal) => Promise<void>;
 
     /** Optional: customize WebSocket construction (auth headers, subprotocols, polyfills). */
     wsFactory: (sessionId: string) => WebSocket;

--- a/src/ui/experimental/camera-control/h264-api.tsx
+++ b/src/ui/experimental/camera-control/h264-api.tsx
@@ -35,6 +35,8 @@ export const COLOUR_MAPPING_OPTIONS: string[] = [
     'helix',
 ];
 
+export const DEFAULT_COLOUR_MAPPING = 'none';
+
 export type ColourMappingOptionsKey = (typeof COLOUR_MAPPING_OPTIONS)[number];
 
 export interface H264Api {

--- a/src/ui/experimental/camera-control/h264-fetch.tsx
+++ b/src/ui/experimental/camera-control/h264-fetch.tsx
@@ -1,4 +1,4 @@
-import { type Crop, type H264Api, DEFAULT_RESOLUTION } from './h264-api';
+import { type Crop, type H264Api, type ColourMappingOptionsKey, DEFAULT_RESOLUTION } from './h264-api';
 
 export function h264FetchApi(url: string): H264Api {
     /**
@@ -113,6 +113,63 @@ export function h264FetchApi(url: string): H264Api {
                 signal: signal,
             });
             if (!res.ok) throw new Error(`Failed to clear crop: ${res.status} ${res.statusText}`);
+        },
+        async getColourMapping(sessionId: string, signal?: AbortSignal) {
+            const res = await fetch(apiUrl + '/sessions/' + sessionId + '/colour_mapping', {
+                method: 'GET',
+                signal: signal,
+            });
+            if (!res.ok) throw new Error(`Failed to get current colour mapping: ${res.status} ${res.statusText}`);
+            const json = await res.json();
+
+            if (!('colour_mapping' in json))
+                throw new Error(`Failed to get current colour mapping: ${JSON.stringify(json)}`);
+            const colour: ColourMappingOptionsKey = json['colour_mapping'];
+            return colour;
+        },
+        async setColourMapping(sessionId: string, colour: ColourMappingOptionsKey, signal?: AbortSignal) {
+            const res = await fetch(apiUrl + '/sessions/' + sessionId + '/colour_mapping', {
+                method: 'POST',
+                signal: signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    colour_mapping: colour,
+                }),
+            });
+            if (!res.ok) throw new Error(`Failed to set colour mapping: ${res.status} ${res.statusText}`);
+            const json = await res.json();
+
+            if (!('colour_mapping' in json))
+                throw new Error(`Failed to get newly set colour mapping: ${JSON.stringify(json)}`);
+            const resPreset: ColourMappingOptionsKey = json['colour_mapping'];
+
+            if (resPreset !== colour) throw new Error(`Failed to set colour mapping: ${JSON.stringify(json)}`);
+            return;
+        },
+        async clearColourMapping(sessionId: string, signal?: AbortSignal) {
+            const DEFAULT_PRESET = 'none';
+            const res = await fetch(apiUrl + '/sessions/' + sessionId + '/colour_mapping', {
+                method: 'POST',
+                signal: signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    colour_mapping: DEFAULT_PRESET,
+                }),
+            });
+            if (!res.ok) throw new Error(`Failed to clear colour mapping: ${res.status} ${res.statusText}`);
+            const json = await res.json();
+
+            if (!('colour_mapping' in json))
+                throw new Error(`Failed to get newly cleared colour mapping: ${JSON.stringify(json)}`);
+            const resPreset: ColourMappingOptionsKey = json['colour_mapping'];
+
+            if (resPreset !== DEFAULT_PRESET)
+                throw new Error(`Failed to clear colour mapping: ${JSON.stringify(json)}`);
+            return;
         },
         wsFactory(sessionId) {
             return new WebSocket(websocketUrl + '?session_id=' + sessionId);

--- a/src/ui/experimental/camera-control/h264-fetch.tsx
+++ b/src/ui/experimental/camera-control/h264-fetch.tsx
@@ -95,8 +95,8 @@ export function h264FetchApi(url: string): H264Api {
             const crop: Crop = await crop_response.json();
             return crop;
         },
-        async setCrop(sessionID: string, crop: Crop, signal?: AbortSignal) {
-            const res = await fetch(apiUrl + '/sessions/' + sessionID + '/crop', {
+        async setCrop(sessionId: string, crop: Crop, signal?: AbortSignal) {
+            const res = await fetch(apiUrl + '/sessions/' + sessionId + '/crop', {
                 method: 'POST',
                 signal: signal,
                 headers: {

--- a/src/ui/experimental/camera-control/h264-fetch.tsx
+++ b/src/ui/experimental/camera-control/h264-fetch.tsx
@@ -1,8 +1,28 @@
 import { type Crop, type H264Api, DEFAULT_RESOLUTION } from './h264-api';
 
 export function h264FetchApi(url: string): H264Api {
-    const apiUrl = 'http://' + url + '/api';
-    const websocketUrl = 'ws://' + url + '/ws';
+    /**
+     * Function to strip http://, https://, etc., protocols from a URL string.
+     *
+     * @param {string} url Url string to strip protocol from
+     * @return {string} Url string without protocol
+     */
+    const stripUrlProtocol = (url: string): string => {
+        try {
+            const { host, pathname, search, hash } = new URL(url);
+            return `${host}${pathname}${search}${hash}`;
+        } catch {
+            // Just return the OG full URL string if the param was unable to be turned into a React-compliant URL() object
+            return url;
+        }
+    };
+
+    const noProtocolUrl = stripUrlProtocol(url);
+
+    const apiUrl = url + '/api';
+
+    const websocketProtocol = new URL(url).protocol === 'https:' ? 'wss://' : 'ws://';
+    const websocketUrl = websocketProtocol + noProtocolUrl + '/ws';
 
     return {
         async createSession(signal) {

--- a/src/ui/experimental/camera-control/h264-fetch.tsx
+++ b/src/ui/experimental/camera-control/h264-fetch.tsx
@@ -1,4 +1,10 @@
-import { type Crop, type H264Api, type ColourMappingOptionsKey, DEFAULT_RESOLUTION } from './h264-api';
+import {
+    type Crop,
+    type H264Api,
+    type ColourMappingOptionsKey,
+    DEFAULT_COLOUR_MAPPING,
+    DEFAULT_RESOLUTION,
+} from './h264-api';
 
 export function h264FetchApi(url: string): H264Api {
     /**
@@ -65,6 +71,7 @@ export function h264FetchApi(url: string): H264Api {
                 signal: signal,
             });
             if (!res.ok) throw new Error(`Failed to get resolution.`);
+
             const data = await res.json();
             return {
                 width: data.source_width,
@@ -86,13 +93,12 @@ export function h264FetchApi(url: string): H264Api {
             return;
         },
         async getCrop(sessionId: string, signal?: AbortSignal) {
-            const crop_response = await fetch(apiUrl + '/sessions/' + sessionId + '/crop', {
+            const res = await fetch(apiUrl + '/sessions/' + sessionId + '/crop', {
                 method: 'GET',
                 signal: signal,
             });
-            if (!crop_response.ok)
-                throw new Error(`Failed to get current crop: ${crop_response.status} ${crop_response.statusText}`);
-            const crop: Crop = await crop_response.json();
+            if (!res.ok) throw new Error(`Failed to get current crop: ${res.status} ${res.statusText}`);
+            const crop: Crop = await res.json();
             return crop;
         },
         async setCrop(sessionId: string, crop: Crop, signal?: AbortSignal) {
@@ -149,7 +155,6 @@ export function h264FetchApi(url: string): H264Api {
             return;
         },
         async clearColourMapping(sessionId: string, signal?: AbortSignal) {
-            const DEFAULT_PRESET = 'none';
             const res = await fetch(apiUrl + '/sessions/' + sessionId + '/colour_mapping', {
                 method: 'POST',
                 signal: signal,
@@ -157,7 +162,7 @@ export function h264FetchApi(url: string): H264Api {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
-                    colour_mapping: DEFAULT_PRESET,
+                    colour_mapping: DEFAULT_COLOUR_MAPPING,
                 }),
             });
             if (!res.ok) throw new Error(`Failed to clear colour mapping: ${res.status} ${res.statusText}`);
@@ -167,7 +172,7 @@ export function h264FetchApi(url: string): H264Api {
                 throw new Error(`Failed to get newly cleared colour mapping: ${JSON.stringify(json)}`);
             const resPreset: ColourMappingOptionsKey = json['colour_mapping'];
 
-            if (resPreset !== DEFAULT_PRESET)
+            if (resPreset !== DEFAULT_COLOUR_MAPPING)
                 throw new Error(`Failed to clear colour mapping: ${JSON.stringify(json)}`);
             return;
         },

--- a/src/ui/experimental/camera-control/h264-fetch.tsx
+++ b/src/ui/experimental/camera-control/h264-fetch.tsx
@@ -1,9 +1,12 @@
 import {
-    type Crop,
     type H264Api,
+    type Crop,
+    type DataIntensity,
+    type DataScaling,
     type ColourMappingOptionsKey,
-    DEFAULT_COLOUR_MAPPING,
     DEFAULT_RESOLUTION,
+    DEFAULT_SCALING,
+    DEFAULT_COLOUR_MAPPING,
 } from './h264-api';
 
 export function h264FetchApi(url: string): H264Api {
@@ -130,8 +133,8 @@ export function h264FetchApi(url: string): H264Api {
 
             if (!('colour_mapping' in json))
                 throw new Error(`Failed to get current colour mapping: ${JSON.stringify(json)}`);
-            const colour: ColourMappingOptionsKey = json['colour_mapping'];
-            return colour;
+            const colourMap: ColourMappingOptionsKey = json['colour_mapping'];
+            return colourMap;
         },
         async setColourMapping(sessionId: string, colour: ColourMappingOptionsKey, signal?: AbortSignal) {
             const res = await fetch(apiUrl + '/sessions/' + sessionId + '/colour_mapping', {
@@ -149,9 +152,9 @@ export function h264FetchApi(url: string): H264Api {
 
             if (!('colour_mapping' in json))
                 throw new Error(`Failed to get newly set colour mapping: ${JSON.stringify(json)}`);
-            const resPreset: ColourMappingOptionsKey = json['colour_mapping'];
+            const colourMap: ColourMappingOptionsKey = json['colour_mapping'];
 
-            if (resPreset !== colour) throw new Error(`Failed to set colour mapping: ${JSON.stringify(json)}`);
+            if (colourMap !== colour) throw new Error(`Failed to set colour mapping: ${JSON.stringify(json)}`);
             return;
         },
         async clearColourMapping(sessionId: string, signal?: AbortSignal) {
@@ -170,10 +173,105 @@ export function h264FetchApi(url: string): H264Api {
 
             if (!('colour_mapping' in json))
                 throw new Error(`Failed to get newly cleared colour mapping: ${JSON.stringify(json)}`);
-            const resPreset: ColourMappingOptionsKey = json['colour_mapping'];
+            const colourMap: ColourMappingOptionsKey = json['colour_mapping'];
 
-            if (resPreset !== DEFAULT_COLOUR_MAPPING)
+            if (colourMap !== DEFAULT_COLOUR_MAPPING)
                 throw new Error(`Failed to clear colour mapping: ${JSON.stringify(json)}`);
+            return;
+        },
+        async getDataIntensity(signal?: AbortSignal) {
+            const res = await fetch(apiUrl + '/data_intensity_range', {
+                method: 'GET',
+                signal: signal,
+            });
+            if (!res.ok) throw new Error(`Failed to get current data intensity range: ${res.status} ${res.statusText}`);
+            const json = await res.json();
+
+            if (!('min_intensity' in json) || !('max_intensity' in json))
+                throw new Error(`Failed to get current data intensity range: ${JSON.stringify(json)}`);
+            const range: DataIntensity = {
+                min: json['min_intensity'],
+                max: json['max_intensity'],
+            };
+            return range;
+        },
+        async setDataIntensity(min: number, max: number, signal?: AbortSignal) {
+            const res = await fetch(apiUrl + '/data_intensity_range', {
+                method: 'POST',
+                signal: signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    min_intensity: min,
+                    max_intensity: max,
+                }),
+            });
+            if (!res.ok) throw new Error(`Failed to set data intensity range: ${res.status} ${res.statusText}`);
+            const json = await res.json();
+
+            if (!('min_intensity' in json) || !('max_intensity' in json))
+                throw new Error(`Failed to get newly set data intensity range: ${JSON.stringify(json)}`);
+
+            if (json['min_intensity'] !== min || json['max_intensity'] !== max)
+                throw new Error(`Failed to set data intensity range: ${JSON.stringify(json)}`);
+            return;
+        },
+        async clearDataIntensity(signal?: AbortSignal) {
+            const res = await fetch(apiUrl + '/data_intensity_range', {
+                method: 'POST',
+                signal: signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    min_intensity: 0,
+                    max_intensity: 0,
+                }),
+            });
+            if (!res.ok) throw new Error(`Failed to clear data intensity range: ${res.status} ${res.statusText}`);
+            return;
+        },
+        async getDataScaling(signal?: AbortSignal) {
+            const res = await fetch(apiUrl + '/data_scaling_power', {
+                method: 'GET',
+                signal: signal,
+            });
+            if (!res.ok) throw new Error(`Failed to get current data scaling power ${res.status} ${res.statusText}`);
+            const scaling: DataScaling = await res.json();
+            return scaling;
+        },
+        async setDataScaling(value: number, signal?: AbortSignal) {
+            const res = await fetch(apiUrl + '/data_scaling_power', {
+                method: 'POST',
+                signal: signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    value: value,
+                }),
+            });
+            if (!res.ok) throw new Error(`Failed to set data scaling power: ${res.status} ${res.statusText}`);
+            const scaling: DataScaling = await res.json();
+
+            if (scaling.value !== value) throw new Error(`Failed to set data scaling power ${JSON.stringify(scaling)}`);
+            return;
+        },
+        async clearDataScaling(signal?: AbortSignal) {
+            const res = await fetch(apiUrl + '/data_scaling_power', {
+                method: 'POST',
+                signal: signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(DEFAULT_SCALING),
+            });
+            if (!res.ok) throw new Error(`Failed to clear data scaling power ${res.status} ${res.statusText}`);
+            const scaling: DataScaling = await res.json();
+
+            if (scaling.value !== DEFAULT_SCALING.value)
+                throw new Error(`Failed to clear data scaling power ${JSON.stringify(scaling)}`);
             return;
         },
         wsFactory(sessionId) {

--- a/src/ui/experimental/camera-control/h264-fetch.tsx
+++ b/src/ui/experimental/camera-control/h264-fetch.tsx
@@ -10,28 +10,25 @@ import {
 } from './h264-api';
 
 export function h264FetchApi(url: string): H264Api {
-    /**
-     * Function to strip http://, https://, etc., protocols from a URL string.
-     *
-     * @param {string} url Url string to strip protocol from
-     * @return {string} Url string without protocol
-     */
-    const stripUrlProtocol = (url: string): string => {
-        try {
-            const { host, pathname, search, hash } = new URL(url);
-            return `${host}${pathname}${search}${hash}`;
-        } catch {
-            // Just return the OG full URL string if the param was unable to be turned into a React-compliant URL() object
-            return url;
-        }
+    let baseUrl: URL | null = null;
+
+    try {
+        baseUrl = new URL(url);
+    } catch (e) {
+        throw new Error(`Failed to create URL from string, ${url}: ${e}`);
+    }
+
+    const apiUrl = new URL(baseUrl.href);
+    apiUrl.pathname += '/api';
+
+    const generateWebsocketUrl = (url: URL): string => {
+        const { host, pathname, search, hash } = url;
+        const noProtocolUrl = `${host}${pathname}${search}${hash}`; // Strip http://, https:// protocol from URL
+        const protocol = url.protocol === 'https:' ? 'wss://' : 'ws://'; // Add the respective ws://, wss:// protocol
+        return protocol + noProtocolUrl + '/ws';
     };
 
-    const noProtocolUrl = stripUrlProtocol(url);
-
-    const apiUrl = url + '/api';
-
-    const websocketProtocol = new URL(url).protocol === 'https:' ? 'wss://' : 'ws://';
-    const websocketUrl = websocketProtocol + noProtocolUrl + '/ws';
+    const websocketUrl = generateWebsocketUrl(baseUrl);
 
     return {
         async createSession(signal) {

--- a/src/ui/experimental/camera-control/h264-fetch.tsx
+++ b/src/ui/experimental/camera-control/h264-fetch.tsx
@@ -225,8 +225,8 @@ export function h264FetchApi(url: string): H264Api {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
-                    min_intensity: 0,
-                    max_intensity: 0,
+                    min_intensity: 0, // TODO: We need an endpoint to get the OG intensities
+                    max_intensity: 0, // TODO: We need an endpoint to get the OG intensities
                 }),
             });
             if (!res.ok) throw new Error(`Failed to clear data intensity range: ${res.status} ${res.statusText}`);

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -139,4 +139,9 @@ export {
     WebsocketH264Provider,
     type WebsocketH264ProviderProps,
 } from './experimental/camera-control/websocket-h264-provider';
+export {
+    type H264Api,
+    type ColourMappingOptionsKey,
+    COLOUR_MAPPING_OPTIONS,
+} from './experimental/camera-control/h264-api';
 export { h264FetchApi } from './experimental/camera-control/h264-fetch';

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -142,6 +142,8 @@ export {
 export {
     type H264Api,
     type ColourMappingOptionsKey,
+    type DataIntensity,
+    type DataScaling,
     COLOUR_MAPPING_OPTIONS,
 } from './experimental/camera-control/h264-api';
 export { h264FetchApi } from './experimental/camera-control/h264-fetch';


### PR DESCRIPTION
* Some tidy up
* Updated the component to take full URLs so it'll know the protocol
* Add colour mapping, data scaling, and data intensity functions

**Note**
Data intensities currently cannot be "reset" because there's no way to retrieve the original intensities after they've been changed. The function just sets them to `0` atm, until that feature exists.