### PR TITLE
Scomp 21 receive and display timestamp h264

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@australiansynchrotron/sci-comp-ui",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "private": false,
     "license": "MIT",
     "author": "Australian Synchrotron",

--- a/src/docs/routes/experimental/camera-control-h264.tsx
+++ b/src/docs/routes/experimental/camera-control-h264.tsx
@@ -15,19 +15,32 @@ export const Route = createFileRoute('/experimental/camera-control-h264')({
     component: CameraControlWebsocketH264Page,
 });
 
+const formatter = new Intl.DateTimeFormat('en-AU', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    fractionalSecondDigits: 3, // milliseconds
+    hour12: false
+    });
+
 /* DEMO_START */
 function CameraControlWebsocketH264Demo() {
     const [mousePos, setMousePos] = useState<CameraMousePosition | null>(null);
     const [clickPos, setClickPos] = useState<CameraMousePosition | null>(null);
+    const [timestamp, setTimestamp] = useState<Date | undefined>(undefined);
     const api = useMemo(() => h264FetchApi('http://localhost:9999/test'), []);
     return (
         <div className="w-full h-full">
+            <div>{timestamp ? "Last frame: " + formatter.format(timestamp) : null}</div>
             <WebsocketH264Provider api={api}>
                 <CameraControl
                     className="border"
                     onMousePositionChange={setMousePos}
                     onClick={setClickPos}
                     showIntensity={true}
+                    onTimestamp={setTimestamp}
                 />
             </WebsocketH264Provider>
             <TypographyH1>
@@ -64,7 +77,7 @@ function CameraControlWebsocketH264Page() {
                 <div className="space-y-6">
                     <Card>
                         <CardHeader>
-                            <CardTitle>Position Control</CardTitle>
+                            <CardTitle>Camera Control</CardTitle>
                             <CardDescription>
                                 <p>
                                     Video display for h264 over websocket streams. Source is the AS Websocket Stream

--- a/src/docs/routes/experimental/camera-control-h264.tsx
+++ b/src/docs/routes/experimental/camera-control-h264.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute('/experimental/camera-control-h264')({
 function CameraControlWebsocketH264Demo() {
     const [mousePos, setMousePos] = useState<CameraMousePosition | null>(null);
     const [clickPos, setClickPos] = useState<CameraMousePosition | null>(null);
-    const api = useMemo(() => h264FetchApi('http://localhost:9999'), []);
+    const api = useMemo(() => h264FetchApi('http://localhost:9999/test'), []);
     return (
         <div className="w-full h-full">
             <WebsocketH264Provider api={api}>

--- a/src/ui/experimental/camera-control/camera-control.tsx
+++ b/src/ui/experimental/camera-control/camera-control.tsx
@@ -43,6 +43,7 @@ export interface CameraControlProps {
     showIntensity?: boolean;
     onZoom?: (box: BoundingBox) => void;
     sizeFollowsImage?: boolean;
+    onTimestamp?: (timestamp: Date | undefined) => void;
     debugFPS?: boolean;
 }
 
@@ -58,6 +59,7 @@ export interface CameraControlProps {
  * @param showIntensity - Whether to show the pixel intensity at mouse position as a tooltip.
  * @param onZoom - Callback called after a bounding box is drawn.
  * @param sizeFollowsImage - Resize the canvas if the image size changes.
+ * @param onTimestamp - Updates with each new timestamp.
  * @param debugFPS - Whether to calculate and display FPS in console log, for debug purposes.
  * @returns
  */
@@ -71,6 +73,7 @@ export const CameraControl: React.FC<CameraControlProps> = ({
     showIntensity = false,
     onZoom,
     sizeFollowsImage = false,
+    onTimestamp,
     debugFPS = false,
 }) => {
     const { image, timestamp, reportSize, reportZoom, reportDrag, clearZoom }: ImageSource = useContext(ImageContext);
@@ -173,6 +176,10 @@ export const CameraControl: React.FC<CameraControlProps> = ({
             setStartTime(now);
         }
     }, [image, startTime, debugFPS]);
+
+    useEffect(() => {
+        onTimestamp?.(timestamp)
+    }, [timestamp, onTimestamp])
 
     // Throttle mouse move
     let lastMove = 0;
@@ -318,21 +325,10 @@ export const CameraControl: React.FC<CameraControlProps> = ({
         e.currentTarget.focus();
     };
 
-    
-    const formatter = new Intl.DateTimeFormat('en-AU', {
-    day: '2-digit',
-    month: 'short',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    fractionalSecondDigits: 3, // milliseconds
-    hour12: false
-    });
-
 
     return (
         <div className={cn('space-y-4 relative inline-block w-full h-full', className)}>
-            <div>{timestamp ? "Last frame:" + formatter.format(timestamp) : null}</div>
+            
             <canvas
                 ref={canvasRef}
                 onMouseMove={handleMouseMove}

--- a/src/ui/experimental/camera-control/camera-control.tsx
+++ b/src/ui/experimental/camera-control/camera-control.tsx
@@ -73,7 +73,7 @@ export const CameraControl: React.FC<CameraControlProps> = ({
     sizeFollowsImage = false,
     debugFPS = false,
 }) => {
-    const { image, reportSize, reportZoom, reportDrag, clearZoom }: ImageSource = useContext(ImageContext);
+    const { image, timestamp, reportSize, reportZoom, reportDrag, clearZoom }: ImageSource = useContext(ImageContext);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [popupPos, setPopupPos] = useState<{ x: number; y: number } | null>(null);
     const [pixelValue, setPixelValue] = useState<string | null>(null);
@@ -318,8 +318,21 @@ export const CameraControl: React.FC<CameraControlProps> = ({
         e.currentTarget.focus();
     };
 
+    
+    const formatter = new Intl.DateTimeFormat('en-AU', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    fractionalSecondDigits: 3, // milliseconds
+    hour12: false
+    });
+
+
     return (
         <div className={cn('space-y-4 relative inline-block w-full h-full', className)}>
+            <div>{timestamp ? "Last frame:" + formatter.format(timestamp) : null}</div>
             <canvas
                 ref={canvasRef}
                 onMouseMove={handleMouseMove}

--- a/src/ui/experimental/camera-control/image-context.tsx
+++ b/src/ui/experimental/camera-control/image-context.tsx
@@ -7,6 +7,7 @@ export interface VideoFrame {
 
 export type ImageSource = {
     image: VideoFrame | ImageBitmap | null;
+    timestamp: Date | undefined;
     reportSize: (width: number, height: number) => void;
     reportZoom: (startX: number, startY: number, width: number, height: number) => void;
     reportDrag: (totalX: number, totalY: number, active: boolean) => void;
@@ -15,6 +16,7 @@ export type ImageSource = {
 
 export const ImageContext = createContext<ImageSource>({
     image: null,
+    timestamp: undefined,
     reportSize: () => {},
     reportZoom: () => {},
     reportDrag: () => {},

--- a/src/ui/experimental/camera-control/websocket-h264-provider.tsx
+++ b/src/ui/experimental/camera-control/websocket-h264-provider.tsx
@@ -40,6 +40,8 @@ export const WebsocketH264Provider: React.FC<WebsocketH264ProviderProps> = ({
     const [currentCropStartY, setCurrentCropStartY] = useState<number>(0);
     const [paddingWidth, setPaddingWidth] = useState<number>(0);
     const [paddingHeight, setPaddingHeight] = useState<number>(0);
+    const [timestamp, setTimestamp] = useState<Date | null>(null);
+    const [timestampDisabled, setTimestampDisabled] = useState<boolean>(false);
 
     // ==================
     // Refs
@@ -98,6 +100,76 @@ export const WebsocketH264Provider: React.FC<WebsocketH264ProviderProps> = ({
 
     const nalType = (nal: Uint8Array) => nal[0] & 0x1f;
     const isKeyframe = (nals: Uint8Array[]) => nals.some((n) => nalType(n) === 5);
+
+    const parseSeiMetadataString = (metadataString: string) => {
+        const metadata: Record<string, string> = {};
+        const pairs = metadataString.split(/[,;\n]+/);
+        for (const pair of pairs) {
+            const trimmed = pair.trim();
+            if (!trimmed || !trimmed.includes('=')) continue;
+            const [key, ...rest] = trimmed.split('=');
+            const value = rest.join('=');
+            if (!key) continue;
+            metadata[key.trim()] = value.trim();
+        }
+        return metadata;
+    };
+
+    // Decode SEI metadata from SEI NAL unit
+    const decodeSeiMetadata = (nal: Uint8Array) => {
+        try {
+            // Skip NAL header byte
+            let offset = 1;
+            
+            // Parse payload_type (variable length, VLC encoding)
+            let payloadType = 0;
+            while (offset < nal.length) {
+                const byte = nal[offset];
+                payloadType += byte;
+                offset++;
+                if (byte !== 0xff) break;
+            }
+            
+            // Parse payload_size (variable length, VLC encoding)
+            let payloadSize = 0;
+            while (offset < nal.length) {
+                const byte = nal[offset];
+                payloadSize += byte;
+                offset++;
+                if (byte !== 0xff) break;
+            }
+            
+            // Check bounds
+            if (offset + payloadSize > nal.length) {
+                console.debug('SEI: payload size', payloadSize, 'exceeds available data');
+                return;
+            }
+            
+            // Extract payload data
+            const payloadData = nal.subarray(offset, offset + payloadSize);
+            
+            // Process unregistered SEI (type 5)
+            if (payloadType === 5 && payloadData.length > 16) {
+                const metadataBytes = payloadData.subarray(16);
+                const metadataString = new TextDecoder().decode(metadataBytes);
+                
+                // Filter out x264 encoder info
+                if (!metadataString.includes('x264') && !metadataString.includes('x265')) {
+                    const metadata = parseSeiMetadataString(metadataString);
+                    if ('timestamp' in metadata) {
+                        const parsed = new Date(metadata.timestamp);
+                        if (!Number.isNaN(parsed.getTime())) {
+                            setTimestamp(parsed);
+                        }
+                    }
+                } else {
+                    console.debug('SEI Encoder Info:', metadataString.substring(0, 50) + '...');
+                }
+            }
+        } catch (e) {
+            console.warn('Failed to decode SEI metadata:', e);
+        }
+    };
 
     const buildAvcC = (spsNal: Uint8Array, ppsNal: Uint8Array): Uint8Array => {
         const spsLen = spsNal.length,
@@ -222,6 +294,7 @@ export const WebsocketH264Provider: React.FC<WebsocketH264ProviderProps> = ({
             const t = nalType(n);
             if (t === 7) spsRef.current = n.slice();
             else if (t === 8) ppsRef.current = n.slice();
+            else if (t === 6 && !timestampDisabled) decodeSeiMetadata(n); // Process SEI metadata
         }
 
         if (!configuredRef.current && spsRef.current && ppsRef.current) {
@@ -273,6 +346,7 @@ export const WebsocketH264Provider: React.FC<WebsocketH264ProviderProps> = ({
                             setCurrentCropHeight(meta.crop_height);
                             setCurrentCropStartX(meta.crop_x);
                             setCurrentCropStartY(meta.crop_y);
+                            setTimestampDisabled(meta.sei_timestamp_disabled);
 
                             const last = lastConfigRef.current;
                             const changed = !last || last.width !== meta.width || last.height !== meta.height;
@@ -502,12 +576,13 @@ export const WebsocketH264Provider: React.FC<WebsocketH264ProviderProps> = ({
     const contextValue = useMemo(
         () => ({
             image: imageBitmap,
+            timestamp: timestampDisabled ? null : timestamp,
             reportSize,
             reportZoom,
             reportDrag,
             clearZoom,
         }),
-        [imageBitmap, reportSize, reportZoom, reportDrag, clearZoom],
+        [imageBitmap, timestamp, reportSize, reportZoom, reportDrag, clearZoom, timestampDisabled],
     );
 
     return <ImageContext.Provider value={contextValue}>{children}</ImageContext.Provider>;


### PR DESCRIPTION
Backend now encodes a source image timestamp into the h264 stream using the SEI user metadata.
In this PR h264 websocket provider receives and decodes this timestamp making it available via the ImageContext.  camera-control receives this timestamp via the context and then exposes it via an onTimestamp callback.